### PR TITLE
Optional torrent category

### DIFF
--- a/components/torrent/TorrentActionCard.vue
+++ b/components/torrent/TorrentActionCard.vue
@@ -44,7 +44,7 @@
 
         <div class="flex flex-col p-6 stats bg-base-100 rounded-2xl">
           <div class="flex flex-col text-sm text-base-content/60">
-            <div class="flex flex-row py-2 pt-0">
+            <div v-if="torrent.category !== null" class="flex flex-row py-2 pt-0">
               <div class="flex flex-row w-1/2">
                 <TagIcon class="w-4 mr-2" />
                 <span>Category</span>

--- a/pages/torrent/edit/[infoHash].vue
+++ b/pages/torrent/edit/[infoHash].vue
@@ -131,7 +131,13 @@ function getTorrentFromApi (infoHash: string) {
 
       form.value.title = data.title;
       form.value.description = data.description;
-      form.value.category = data.category.category_id;
+
+      if (typeof data.category === "object" && "category_id" in data.category) {
+        form.value.category = data.category.category_id;
+      } else {
+        form.value.category = null;
+      }
+
       form.value.tags = data.tags.map((tag) => {
         if (typeof tag === "object" && "tag_id" in tag) {
           return tag.tag_id;

--- a/pages/torrent/edit/[infoHash].vue
+++ b/pages/torrent/edit/[infoHash].vue
@@ -45,15 +45,17 @@
           </select>
         </div>
       </template>
-      <div>
-        <label for="tags" class="px-2">Tags</label>
-        <TorrustSelect
-          v-model:selected="form.tags"
-          :options="tags.map(entry => ({ name: entry.name, value: entry.tag_id }))"
-          :multiple="true"
-          search
-        />
-      </div>
+      <template v-if="tags?.length > 0">
+        <div>
+          <label for="tags" class="px-2">Tags</label>
+          <TorrustSelect
+            v-model:selected="form.tags"
+            :options="tags.map(entry => ({ name: entry.name, value: entry.tag_id }))"
+            :multiple="true"
+            search
+          />
+        </div>
+      </template>
       <template v-if="user?.username">
         <button
           class="btn btn-primary"
@@ -132,10 +134,10 @@ function getTorrentFromApi (infoHash: string) {
       form.value.title = data.title;
       form.value.description = data.description;
 
-      if (typeof data.category === "object" && "category_id" in data.category) {
-        form.value.category = data.category.category_id;
-      } else {
+      if (data.category === null) {
         form.value.category = null;
+      } else {
+        form.value.category = data.category.category_id;
       }
 
       form.value.tags = data.tags.map((tag) => {
@@ -154,7 +156,7 @@ function getTorrentFromApi (infoHash: string) {
 }
 
 function formValid () {
-  return form.value.title && (form.value.title + form.value.description) !== (torrent.value.title + torrent.value.description + torrent.value.category.name);
+  return form.value.title && form.value.description;
 }
 
 function submitForm () {


### PR DESCRIPTION
Torrent category is now optional, which means the response from the API can contain a `null` instead of a category o object.

Relates to: https://github.com/torrust/torrust-index-backend/issues/96