### PR TITLE
Fix list mode tab selector overlapping filter popups

### DIFF
--- a/components/TorrustSelect.vue
+++ b/components/TorrustSelect.vue
@@ -10,7 +10,7 @@
         </div>
       </div>
     </label>
-    <div ref="dropdownContent" tabindex="0" class="flex flex-col gap-2 p-2 mt-3 border rounded-lg shadow dropdown-content border-base-content/20 bg-base-100">
+    <div ref="dropdownContent" tabindex="0" class="flex flex-col gap-2 p-2 mt-3 border rounded-lg shadow dropdown-content border-base-content/20 bg-base-100 z-[1]">
       <template v-if="props.search">
         <div class="">
           <input

--- a/components/dropdown/DropdownMenu.vue
+++ b/components/dropdown/DropdownMenu.vue
@@ -1,7 +1,0 @@
-<script>
-
-</script>
-
-<style scoped>
-
-</style>


### PR DESCRIPTION
The buttons for selecting the list mode (Default|Table) were rendered on top of the category/tags popup div, mixing up both components.

Problem:

![image](https://github.com/torrust/torrust-index-frontend/assets/58816/e4e9481d-cde9-4fdb-ad13-579940493cf9)

Fixed:

![image](https://github.com/torrust/torrust-index-frontend/assets/58816/0318138f-734d-4e79-b8ba-b143cfa66f7f)
