### PR TITLE
E2E test: torrent upload

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@
 /temp-package/
 /temp-package/api/
 cypress/downloads/**/*
+cypress/fixtures/torrents/file-*.txt.torrent
 cypress/screenshots/**/*.png
 cypress/videos/**/*.mp4
 dist

--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@
 *.log*
 /temp-package/
 /temp-package/api/
+cypress/downloads/**/*
 cypress/screenshots/**/*.png
 cypress/videos/**/*.mp4
 dist

--- a/components/TorrustButton.vue
+++ b/components/TorrustButton.vue
@@ -1,6 +1,7 @@
 <template>
   <button
-    class="px-6 h-12 btn btn-primary w-full inline-flex justify-center items-center appearance-none capitalize rounded-2xl cursor-pointer duration-500 disabled:bg-neutral-600 disabled:text-neutral-content/50"
+    :data-cy="props.dataCy"
+    class="inline-flex items-center justify-center w-full h-12 px-6 capitalize duration-500 appearance-none cursor-pointer btn btn-primary rounded-2xl disabled:bg-neutral-600 disabled:text-neutral-content/50"
     :label="label"
   >
     {{ label }}
@@ -12,6 +13,12 @@ const props = defineProps({
   label: {
     type: String,
     required: true,
+    default: () => ""
+  },
+  // https://docs.cypress.io/guides/references/best-practices#Selecting-Elements
+  dataCy: {
+    type: String,
+    required: false,
     default: () => ""
   }
 });

--- a/components/upload/UploadFile.vue
+++ b/components/upload/UploadFile.vue
@@ -12,6 +12,7 @@
       hidden
       name="torrent-upload"
       type="file"
+      data-cy="upload-form-torrent-upload"
       class="sr-only"
       :accept="accept"
       @change="onChange"

--- a/cypress.config.ts
+++ b/cypress.config.ts
@@ -1,5 +1,6 @@
 import { defineConfig } from "cypress";
 import { grantAdminRole } from "./cypress/e2e/contexts/user/tasks";
+import { deleteTorrent } from "./cypress/e2e/contexts/torrent/tasks";
 import { DatabaseConfig } from "./cypress/e2e/common/database";
 
 function databaseConfig (config: Cypress.PluginConfigOptions): DatabaseConfig {
@@ -15,6 +16,9 @@ export default defineConfig({
       on("task", {
         grantAdminRole: ({ username }) => {
           return grantAdminRole(username, databaseConfig(config));
+        },
+        deleteTorrent: ({ infohash }) => {
+          return deleteTorrent(infohash, databaseConfig(config));
         }
       });
     }

--- a/cypress/e2e/contexts/torrent/specs/upload.cy.ts
+++ b/cypress/e2e/contexts/torrent/specs/upload.cy.ts
@@ -16,8 +16,6 @@ describe("A registered user", () => {
   it("should be able to upload a torrent", () => {
     const torrent_info = generateRandomTestTorrentInfo();
 
-    cy.log("download a new test random torrent");
-
     cy.request({
       url: `http://localhost:3001/v1/torrent/meta-info/random/${torrent_info.id}`,
       encoding: "binary"
@@ -31,26 +29,24 @@ describe("A registered user", () => {
     cy.get("input[data-cy=\"upload-form-title\"]").type(torrent_info.title);
     cy.get("textarea[data-cy=\"upload-form-description\"]").type(torrent_info.description);
     cy.get("select[data-cy=\"upload-form-category\"]").select("software");
-
-    // todo: add tag.
-    // By default there are no tags, so we need to create them first with
-    // a custom command. We can enable this feature after writing the test for
-    // the tags context.  We could even create some tags before running all the
-    // tests.
-    // cy.get("input[data-cy=\"upload-form-tags\"]").select('fractals');
-
     cy.get("input[data-cy=\"upload-form-torrent-upload\"]").selectFile(
       {
         contents: torrent_info.path,
         fileName: torrent_info.filename,
         mimeType: "application/x-bittorrent"
       }, { force: true });
+    // todo: add tag.
+    // By default there are no tags, so we need to create them first with
+    // a custom command. We can enable this feature after writing the test for
+    // the tags context.  We could even create some tags before running all the
+    // tests.
+    // cy.get("input[data-cy=\"upload-form-torrent-upload\"]").select('fractals');
 
     cy.get("button[data-cy=\"upload-form-submit\"]").click();
 
+    // It should redirect to the torrent detail page.
     cy.url().should("include", "/torrent/");
 
-    // todo: delete the dinamically created torrent file in `cypress/fixtures/torrents` 
-    // folder.
+    cy.exec(`rm ${torrent_info.path}`);
   });
 });

--- a/cypress/e2e/contexts/torrent/specs/upload.cy.ts
+++ b/cypress/e2e/contexts/torrent/specs/upload.cy.ts
@@ -1,27 +1,5 @@
+import { v4 as uuidv4 } from "uuid";
 import { RegistrationForm, random_user_registration_data } from "../../user/registration";
-
-// It extracts the filename from the content-disposition header.
-//
-// For example:
-//
-// From: attachment; filename=file-6dcf841b-bc75-4a2e-9aa0-8ca63b49df18.txt.torrent
-// It returns: file-6dcf841b-bc75-4a2e-9aa0-8ca63b49df18.txt.torrent
-function extractFilename (contentDisposition: string): string {
-  if (contentDisposition && contentDisposition.includes("attachment")) {
-    return contentDisposition.split(";")[1].split("=")[1].replace(/\"/g, "");
-  }
-  return "";
-}
-
-// It extracts the test torrent ID from the torrent file name.
-//
-// For example:
-//
-// From: file-6dcf841b-bc75-4a2e-9aa0-8ca63b49df18.txt.torrent
-// It returns: 6dcf841b-bc75-4a2e-9aa0-8ca63b49df18
-function extractTorrentIdFromFilename (filename: string): string {
-  return filename.split(".")[0].split("file-")[1];
-}
 
 describe("A registered user", () => {
   let registration_form: RegistrationForm;
@@ -36,44 +14,26 @@ describe("A registered user", () => {
   });
 
   it("should be able to upload a torrent", () => {
-    let torrentId = "";
+    let torrentId = uuidv4();
+    let torrentTitle = `title-${torrentId}`;
+    let torrentDescription = `title-${torrentId}`;
+    let torrentFilename = `file-${torrentId}.txt.torrent`;
+    let torrentPath = `cypress/fixtures/torrents/${torrentFilename}`;
 
-    cy.log("download a random torrent for the test");
+    cy.log("download a new test random torrent");
 
     cy.request({
-      url: "http://localhost:3001/v1/torrents/random",
+      url: `http://localhost:3001/v1/torrent/meta-info/random/${torrentId}`,
       encoding: "binary"
     }).then((response) => {
-      cy.log("random torrent downloaded");
-
-      const header = response.headers["content-disposition"];
-
-      let contentDisposition: string;
-      if (typeof header === "string") {
-        contentDisposition = header;
-      } else {
-        contentDisposition = header[0];
-      }
-
-      const filename = extractFilename(contentDisposition);
-      const torrentPath = `cypress/fixtures/torrents/${filename}`;
-      torrentId = extractTorrentIdFromFilename(filename);
-
-      // Alias the torrentId for later use
-      cy.wrap(torrentId).as("torrentId");
-
-      cy.log("torrent ID: ", torrentId);
-      cy.log("random torrent downloaded: ", torrentPath);
-
+      cy.log("random torrent downloaded to: ", torrentPath);
       cy.writeFile(torrentPath, response.body, "binary");
     });
 
     cy.visit("/upload");
 
-    cy.get("@torrentId").then((torrentId) => {
-      cy.get("input[data-cy=\"upload-form-title\"]").type(`title-${torrentId}`);
-      cy.get("textarea[data-cy=\"upload-form-description\"]").type(`description-${torrentId}`);
-    });
+    cy.get("input[data-cy=\"upload-form-title\"]").type(torrentTitle);
+    cy.get("textarea[data-cy=\"upload-form-description\"]").type(torrentDescription);
     cy.get("select[data-cy=\"upload-form-category\"]").select("software");
 
     // todo: add tag.
@@ -83,14 +43,12 @@ describe("A registered user", () => {
     // tests.
     // cy.get("input[data-cy=\"upload-form-tags\"]").select('fractals');
 
-    cy.get("@torrentId").then((torrentId) => {
-      cy.get("input[data-cy=\"upload-form-torrent-upload\"]").selectFile(
-        {
-          contents: `cypress/fixtures/torrents/file-${torrentId}.txt.torrent`,
-          fileName: `file-${torrentId}.torrent`,
-          mimeType: "application/x-bittorrent"
-        }, { force: true });
-    });
+    cy.get("input[data-cy=\"upload-form-torrent-upload\"]").selectFile(
+      {
+        contents: torrentPath,
+        fileName: torrentFilename,
+        mimeType: "application/x-bittorrent"
+      }, { force: true });
 
     cy.get("button[data-cy=\"upload-form-submit\"]").click();
 

--- a/cypress/e2e/contexts/torrent/specs/upload.cy.ts
+++ b/cypress/e2e/contexts/torrent/specs/upload.cy.ts
@@ -1,0 +1,99 @@
+import { RegistrationForm, random_user_registration_data } from "../../user/registration";
+
+// It extracts the filename from the content-disposition header.
+//
+// For example:
+//
+// From: attachment; filename=file-6dcf841b-bc75-4a2e-9aa0-8ca63b49df18.txt.torrent
+// It returns: file-6dcf841b-bc75-4a2e-9aa0-8ca63b49df18.txt.torrent
+function extractFilename (contentDisposition: string): string {
+  if (contentDisposition && contentDisposition.includes("attachment")) {
+    return contentDisposition.split(";")[1].split("=")[1].replace(/\"/g, "");
+  }
+  return "";
+}
+
+// It extracts the test torrent ID from the torrent file name.
+//
+// For example:
+//
+// From: file-6dcf841b-bc75-4a2e-9aa0-8ca63b49df18.txt.torrent
+// It returns: 6dcf841b-bc75-4a2e-9aa0-8ca63b49df18
+function extractTorrentIdFromFilename (filename: string): string {
+  return filename.split(".")[0].split("file-")[1];
+}
+
+describe("A registered user", () => {
+  let registration_form: RegistrationForm;
+
+  before(() => {
+    registration_form = random_user_registration_data();
+
+    cy.visit("/");
+    cy.visit("/signup");
+    cy.register(registration_form);
+    cy.login(registration_form.username, registration_form.password);
+  });
+
+  it("should be able to upload a torrent", () => {
+    let torrentId = "";
+
+    cy.log("download a random torrent for the test");
+
+    cy.request({
+      url: "http://localhost:3001/v1/torrents/random",
+      encoding: "binary"
+    }).then((response) => {
+      cy.log("random torrent downloaded");
+
+      const header = response.headers["content-disposition"];
+
+      let contentDisposition: string;
+      if (typeof header === "string") {
+        contentDisposition = header;
+      } else {
+        contentDisposition = header[0];
+      }
+
+      const filename = extractFilename(contentDisposition);
+      const torrentPath = `cypress/fixtures/torrents/${filename}`;
+      torrentId = extractTorrentIdFromFilename(filename);
+
+      // Alias the torrentId for later use
+      cy.wrap(torrentId).as("torrentId");
+
+      cy.log("torrent ID: ", torrentId);
+      cy.log("random torrent downloaded: ", torrentPath);
+
+      cy.writeFile(torrentPath, response.body, "binary");
+    });
+
+    cy.visit("/upload");
+
+    cy.get("@torrentId").then((torrentId) => {
+      cy.get("input[data-cy=\"upload-form-title\"]").type(`title-${torrentId}`);
+      cy.get("textarea[data-cy=\"upload-form-description\"]").type(`description-${torrentId}`);
+    });
+    cy.get("select[data-cy=\"upload-form-category\"]").select("software");
+
+    // todo: add tag.
+    // By default there are no tags, so we need to create them first with
+    // a custom command. We can enable this feature after writing the test for
+    // the tags context.  We could even create some tags before running all the
+    // tests.
+    // cy.get("input[data-cy=\"upload-form-tags\"]").select('fractals');
+
+    cy.get("@torrentId").then((torrentId) => {
+      cy.get("input[data-cy=\"upload-form-torrent-upload\"]").selectFile(
+        {
+          contents: `cypress/fixtures/torrents/file-${torrentId}.txt.torrent`,
+          fileName: `file-${torrentId}.torrent`,
+          mimeType: "application/x-bittorrent"
+        }, { force: true });
+    });
+
+    cy.get("button[data-cy=\"upload-form-submit\"]").click();
+
+    cy.url().should("include", "/torrent/");
+  });
+});

--- a/cypress/e2e/contexts/torrent/specs/upload.cy.ts
+++ b/cypress/e2e/contexts/torrent/specs/upload.cy.ts
@@ -1,5 +1,5 @@
-import { v4 as uuidv4 } from "uuid";
 import { RegistrationForm, random_user_registration_data } from "../../user/registration";
+import { generateRandomTestTorrentInfo } from "../test_torrent_info";
 
 describe("A registered user", () => {
   let registration_form: RegistrationForm;
@@ -14,26 +14,22 @@ describe("A registered user", () => {
   });
 
   it("should be able to upload a torrent", () => {
-    let torrentId = uuidv4();
-    let torrentTitle = `title-${torrentId}`;
-    let torrentDescription = `title-${torrentId}`;
-    let torrentFilename = `file-${torrentId}.txt.torrent`;
-    let torrentPath = `cypress/fixtures/torrents/${torrentFilename}`;
+    const torrent_info = generateRandomTestTorrentInfo();
 
     cy.log("download a new test random torrent");
 
     cy.request({
-      url: `http://localhost:3001/v1/torrent/meta-info/random/${torrentId}`,
+      url: `http://localhost:3001/v1/torrent/meta-info/random/${torrent_info.id}`,
       encoding: "binary"
     }).then((response) => {
-      cy.log("random torrent downloaded to: ", torrentPath);
-      cy.writeFile(torrentPath, response.body, "binary");
+      cy.log("random torrent downloaded to: ", torrent_info.path);
+      cy.writeFile(torrent_info.path, response.body, "binary");
     });
 
     cy.visit("/upload");
 
-    cy.get("input[data-cy=\"upload-form-title\"]").type(torrentTitle);
-    cy.get("textarea[data-cy=\"upload-form-description\"]").type(torrentDescription);
+    cy.get("input[data-cy=\"upload-form-title\"]").type(torrent_info.title);
+    cy.get("textarea[data-cy=\"upload-form-description\"]").type(torrent_info.description);
     cy.get("select[data-cy=\"upload-form-category\"]").select("software");
 
     // todo: add tag.
@@ -45,13 +41,16 @@ describe("A registered user", () => {
 
     cy.get("input[data-cy=\"upload-form-torrent-upload\"]").selectFile(
       {
-        contents: torrentPath,
-        fileName: torrentFilename,
+        contents: torrent_info.path,
+        fileName: torrent_info.filename,
         mimeType: "application/x-bittorrent"
       }, { force: true });
 
     cy.get("button[data-cy=\"upload-form-submit\"]").click();
 
     cy.url().should("include", "/torrent/");
+
+    // todo: delete the dinamically created torrent file in `cypress/fixtures/torrents` 
+    // folder.
   });
 });

--- a/cypress/e2e/contexts/torrent/tasks.ts
+++ b/cypress/e2e/contexts/torrent/tasks.ts
@@ -1,0 +1,22 @@
+// Custom tasks for user context
+
+import { DatabaseConfig, DatabaseQuery, runDatabaseQuery } from "../../common/database";
+
+// Task to grant admin role to a user by username
+export const deleteTorrent = async (infohash: string, db_config: DatabaseConfig): Promise<boolean> => {
+  try {
+    await runDatabaseQuery(deleteTorrentQuery(infohash), db_config);
+    return true;
+  } catch (err) {
+    return await Promise.reject(err);
+  }
+};
+
+// Database query specifications
+
+function deleteTorrentQuery (infohash: string): DatabaseQuery {
+  return {
+    query: "DELETE FROM torrust_torrents WHERE info_hash = ?",
+    params: [infohash]
+  };
+}

--- a/cypress/e2e/contexts/torrent/test_torrent_info.ts
+++ b/cypress/e2e/contexts/torrent/test_torrent_info.ts
@@ -1,0 +1,25 @@
+import { v4 as uuidv4 } from "uuid";
+
+export type TestTorrentInfo = {
+    id: string,
+    title: string,
+    description: string,
+    filename: string,
+    path: string
+  };
+
+// It generates the information for a random torrent file.
+// You can download the torrent file (meta-info file) from the server and saved
+// in the `cypress/fixtures/torrents` folder.
+export function generateRandomTestTorrentInfo (): TestTorrentInfo {
+  const torrentId = uuidv4();
+  const torrentFilename = `file-${torrentId}.txt.torrent`;
+
+  return {
+    id: torrentId,
+    title: `title-${torrentId}`,
+    description: `description-${torrentId}`,
+    filename: `file-${torrentId}.txt.torrent`,
+    path: `cypress/fixtures/torrents/${torrentFilename}`
+  };
+}

--- a/cypress/fixtures/torrents/mandelbrot_set_01.torrent
+++ b/cypress/fixtures/torrents/mandelbrot_set_01.torrent
@@ -1,0 +1,2 @@
+d7:comment17:Mandelbrot Set 0110:created by30:Transmission/3.00 (bb6b5a062e)13:creation datei1687937540e8:encoding5:UTF-84:infod6:lengthi602515e4:name17:mandelbrot_set_0112:piece lengthi32768e6:pieces380:Šˆ2¾í_ªÄ¯JKš¿ìƒBs9¸Ö ,ÑŠS(µÔ#
+#ÈÛ¬ÄækÇ¤­dEpí‘ñ8çßÐÉ#'|ÑùÔå¡_õå äžû±CõK­ÔËI÷æ{º0_¯ùˆVûEš´•’>,Ú¦Ó‚çc£»K(óWÇË}ŒãF«×èŽŠŒŸÇæÅÅd‚íG»*ñ·?¥<[œ¯Cì*áhšIÈ¿­¾é-~¾œL¡—T:”`\iAF<š7öbO•Às’ÊšÕ©‰¬‹…Sûâ–&>&¦[pSHeól'k½îë_w¨Ø¯Ø‚Jà´b¼ñ¥õòÇ`ø8È[©Ý†úÀ{ð&×ÑšBÃŸ¹YƒbAé<m¡uW%ž·þß‘ÔQKmD1Ž„&•01ð,9½SÏÓ^>A©?s$¬^žüMÅpEE‹›RæÐ&GCž*|Å’Õ†6þHé¸†„’#I[îÄ1²uŽL„7:privatei0eee

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,12 +7,14 @@
       "hasInstallScript": true,
       "dependencies": {
         "@heroicons/vue": "^2.0.18",
+        "@types/uuid": "^9.0.2",
         "daisyui": "^3.2.1",
         "dompurify": "^3.0.5",
         "marked": "^5.1.1",
         "notiwind-ts": "^2.0.2",
         "torrust-index-api-lib": "^0.2.0",
-        "torrust-index-types-lib": "^0.2.0"
+        "torrust-index-types-lib": "^0.2.0",
+        "uuid": "^9.0.0"
       },
       "devDependencies": {
         "@nuxt/devtools": "^0.6.7",
@@ -766,6 +768,15 @@
       },
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/@cypress/request/node_modules/uuid": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+      "dev": true,
+      "bin": {
+        "uuid": "dist/bin/uuid"
       }
     },
     "node_modules/@cypress/xvfb": {
@@ -3700,6 +3711,11 @@
       "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.3.tgz",
       "integrity": "sha512-NfQ4gyz38SL8sDNrSixxU2Os1a5xcdFxipAFxYEuLUlvU2uDwS4NUpsImcf1//SlWItCVMMLiylsxbmNMToV/g==",
       "dev": true
+    },
+    "node_modules/@types/uuid": {
+      "version": "9.0.2",
+      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-9.0.2.tgz",
+      "integrity": "sha512-kNnC1GFBLuhImSnV7w4njQkUiJi0ZXUycu1rUaouPqiKlXkh77JKgdRnTAp1x5eBwcIwbtI+3otwzuIDEuDoxQ=="
     },
     "node_modules/@types/yauzl": {
       "version": "2.10.0",
@@ -20095,10 +20111,9 @@
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="
     },
     "node_modules/uuid": {
-      "version": "8.3.2",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
-      "dev": true,
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.0.tgz",
+      "integrity": "sha512-MXcSTerfPa4uqyzStbRoTgt5XIe3x5+42+q1sDuy3R5MDk66URdLMOZe5aPX/SQd+kuYAh0FdP/pO28IkQyTeg==",
       "bin": {
         "uuid": "dist/bin/uuid"
       }

--- a/package.json
+++ b/package.json
@@ -34,11 +34,13 @@
   },
   "dependencies": {
     "@heroicons/vue": "^2.0.18",
+    "@types/uuid": "^9.0.2",
     "daisyui": "^3.2.1",
     "dompurify": "^3.0.5",
     "marked": "^5.1.1",
     "notiwind-ts": "^2.0.2",
     "torrust-index-api-lib": "^0.2.0",
-    "torrust-index-types-lib": "^0.2.0"
+    "torrust-index-types-lib": "^0.2.0",
+    "uuid": "^9.0.0"
   }
 }

--- a/pages/upload.vue
+++ b/pages/upload.vue
@@ -6,7 +6,14 @@
     <div class="flex flex-col w-full max-w-xl gap-6">
       <div>
         <label for="title" class="px-2">Title</label>
-        <input id="title" v-model="form.title" name="title" type="text" class="mt-1">
+        <input
+          id="title"
+          v-model="form.title"
+          name="title"
+          type="text"
+          data-cy="upload-form-title"
+          class="mt-1"
+        >
       </div>
       <div>
         <label for="description" class="px-2">Description</label>
@@ -23,6 +30,7 @@
             id="description"
             v-model="form.description"
             name="description"
+            data-cy="upload-form-description"
             rows="8"
             class="mt-1"
           />
@@ -36,7 +44,7 @@
       <template v-if="categories?.length > 0">
         <div>
           <label for="category" class="px-2">Category</label>
-          <select id="category" v-model="form.category" class="mt-1">
+          <select id="category" v-model="form.category" data-cy="upload-form-category" class="mt-1">
             <template v-for="option in categories">
               <option :value="option.name">
                 {{ option.name }}
@@ -62,6 +70,7 @@
       <template v-if="user?.username">
         <TorrustButton
           label="submit"
+          data-cy="upload-form-submit"
           :disabled="!formValid() || uploading"
           @click="submitForm"
         />

--- a/project-words.txt
+++ b/project-words.txt
@@ -1,5 +1,7 @@
 composables
 dompurify
+filedrag
+filelist
 heroicons
 notiwind
 Nuxt

--- a/project-words.txt
+++ b/project-words.txt
@@ -8,4 +8,5 @@ Nuxt
 nuxtjs
 proxied
 signin
+uuidv
 vuex

--- a/project-words.txt
+++ b/project-words.txt
@@ -4,6 +4,7 @@ dompurify
 filedrag
 filelist
 heroicons
+infohash
 notiwind
 Nuxt
 nuxtjs

--- a/project-words.txt
+++ b/project-words.txt
@@ -1,4 +1,5 @@
 composables
+dinamically
 dompurify
 filedrag
 filelist


### PR DESCRIPTION
E2E test for torrent upload.

### Strategy

I want to:

- Generate a random torrent file on-the-fly
- Select the torrent and submit the form
- Assert that the app redirects to the torrent detail page with the right metadata: title. description, category, ...

### Current status

It works with a fixed torrent file fixture. 

Example of the test passing on CI: https://github.com/torrust/torrust-index-frontend/actions/runs/5546141538/jobs/10126011522?pr=185#step:7:684

But the problem is I want to generate a random torrent file like in the [backend](https://github.com/torrust/torrust-index-backend/blob/develop/tests/common/contexts/torrent/file.rs) to be able to run the test many times. If you try to rerun the same test, it will fail because the torrent already exists in the database.

In the [backend](https://github.com/torrust/torrust-index-backend/blob/develop/tests/common/contexts/torrent/file.rs), we solved it by using a console command to generate the torrent file. Here it's not possible because with Cypress, we cannot use:

- Asynchronous functions in custom commands
- Use packages which need to access the filesystem.

Since it's run in the browser,

### Screenshot

![image](https://github.com/torrust/torrust-index-frontend/assets/58816/29d97755-d0be-4c4f-acd8-23de43230c2d)
