### PR TITLE
Fix browser console warning: ` Incorrect use of label for=FORM_ELEMENT`

### DIFF
--- a/components/TorrustSelect.vue
+++ b/components/TorrustSelect.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="group dropdown" :class="dropdownAlignment">
-    <label tabindex="0" class="items-center duration-200 select select-bordered group-hover:border-amber-500" :class="{ 'h-[3.5rem]': !!label }">
+    <div tabindex="0" class="items-center duration-200 select select-bordered group-hover:border-amber-500" :class="{ 'h-[3.5rem]': !!label }">
       <div class="flex flex-col mr-1 text-left capitalize flex-nowrap">
         <span v-if="label" class="text-xs text-primary">{{ label }}</span>
         <div class="flex flex-row text-sm flex-nowrap">
@@ -9,7 +9,7 @@
           <span v-else>{{ getOptionNameByValue(props.selected[0]) }}</span>
         </div>
       </div>
-    </label>
+    </div>
     <div ref="dropdownContent" tabindex="0" class="flex flex-col gap-2 p-2 mt-3 border rounded-lg shadow dropdown-content border-base-content/20 bg-base-100 z-[1]">
       <template v-if="props.search">
         <div class="">
@@ -17,6 +17,7 @@
             v-model="searchText"
             class="text-sm border-2 input placeholder-base-content input-bordered rounded-2xl"
             placeholder="Search"
+            name="search"
           >
         </div>
       </template>

--- a/components/navigation/NavigationBar.vue
+++ b/components/navigation/NavigationBar.vue
@@ -20,12 +20,12 @@
         >
       </div>
       <div class="hidden px-2 dropdown dropdown-hover md:inline-block text-base-content/75 hover:text-base-content">
-        <label tabindex="0" class="px-1">
+        <div tabindex="0" class="px-1">
           <NuxtLink to="/torrents" class="flex">
             Torrents
             <ChevronDownIcon class="w-5 ml-2" />
           </NuxtLink>
-        </label>
+        </div>
         <ul tabindex="0" class="p-2 rounded shadow menu dropdown-content bg-base-100 w-52">
           <li><NuxtLink to="/torrents?sorting=LeechersDesc">
             Most Popular
@@ -41,11 +41,11 @@
             Upload Torrent
           </NuxtLink>
           <div class="dropdown dropdown-end z-[1]">
-            <label tabindex="0" class="btn btn-ghost btn-circle avatar">
+            <div tabindex="0" class="btn btn-ghost btn-circle avatar">
               <div class="w-10 rounded-full">
                 <UserCircleIcon />
               </div>
-            </label>
+            </div>
             <ul tabindex="0" class="p-2 mt-3 shadow menu dropdown-content bg-base-100 rounded-box w-52">
               <li v-if="user.admin" data-cy="admin-settings-link"><NuxtLink to="/admin/settings/backend">
                 Admin Settings


### PR DESCRIPTION
This is a work-in-progress pull request that aims to clear the runtime-errors and warnings in the frontend.

For now we have 2 left, still pending to look further ⬇
![image](https://github.com/torrust/torrust-index-frontend/assets/64548160/e395955c-cfe8-41e2-ad3c-cc74111876a8)

