### PR TITLE
Fix for [#247] search bar not working when in /torrents endpoint

### DIFF
--- a/app.vue
+++ b/app.vue
@@ -6,7 +6,7 @@
 
     <div class="flex flex-col w-full px-4 bg-base-300 md:px-8 lg:px-24">
       <div class="flex flex-col my-6" style="max-width: 100vw;">
-        <NuxtPage :page-key="route => route.fullPath" />
+        <NuxtPage />
       </div>
 
       <footer class="p-4 footer footer-center bg-base-300 text-base-content">

--- a/app.vue
+++ b/app.vue
@@ -6,7 +6,7 @@
 
     <div class="flex flex-col w-full px-4 bg-base-300 md:px-8 lg:px-24">
       <div class="flex flex-col my-6" style="max-width: 100vw;">
-        <NuxtPage />
+        <NuxtPage :page-key="route => route.fullPath" />
       </div>
 
       <footer class="p-4 footer footer-center bg-base-300 text-base-content">

--- a/components/navigation/NavigationBar.vue
+++ b/components/navigation/NavigationBar.vue
@@ -109,10 +109,8 @@
 import { UserCircleIcon, Bars3Icon, MagnifyingGlassIcon } from "@heroicons/vue/24/solid";
 import { ChevronDownIcon } from "@heroicons/vue/20/solid";
 import { Ref } from "vue";
-import { useRouter } from "#app";
 import { ref, useSettings, useUser, logoutUser } from "#imports";
 
-const router = useRouter();
 const settings = useSettings();
 const user = useUser();
 
@@ -121,7 +119,7 @@ const searchQuery: Ref<string> = ref("");
 const typingInSearch = ref(false);
 
 function submitSearch () {
-  router.push({
+  navigateTo({
     path: "/torrents",
     query: {
       search: searchQuery.value ?? null

--- a/pages/torrents.vue
+++ b/pages/torrents.vue
@@ -106,10 +106,8 @@ const selectedSorting = computed({
   }
 });
 
-watch([route], () => {
-  if (route.query.search !== searchQuery.value) {
-    searchQuery.value = route.query.search as string;
-  }
+watch(() => route.fullPath, () => {
+  searchQuery.value = route.query.search as string;
 });
 
 watch([searchQuery, itemsSorting, pageSize, currentPage, layout, categoryFilters, tagFilters], () => {


### PR DESCRIPTION
Fixes #247 

The search bar was not working when in the /torrents endpoint, because the watcher listening for changes in the url path was not triggering when the user searches for a specific torrent.