### PR TITLE
Fixes [257] unnecessary repetitive requests using the search bar

### DIFF
--- a/pages/torrents.vue
+++ b/pages/torrents.vue
@@ -126,8 +126,11 @@ watch([searchQuery, itemsSorting, pageSize, currentPage, layout, categoryFilters
   loadTorrents();
 });
 
-onMounted(() => {
+onActivated(() => {
   searchQuery.value = route.query.search as string ?? null;
+});
+
+onMounted(() => {
   loadTorrents();
 });
 


### PR DESCRIPTION
Fixes #257 

Assigning the search query value to the variable used to fetch the searched torrents is now done through the onActivated hook, avoiding triggering the watchers, and thus, not making another unnecessary fetch request to the back-end, getting the torrents only once.