### PR TITLE
fix: import nuxt composables from `#imports`

### DIFF
--- a/components/torrent/TorrentDetails.vue
+++ b/components/torrent/TorrentDetails.vue
@@ -43,7 +43,7 @@ import { ChevronLeftIcon } from "@heroicons/vue/24/solid";
 import { Ref } from "vue";
 import { TorrentResponse } from "torrust-index-types-lib";
 import { notify } from "notiwind-ts";
-import { useRoute } from "#app";
+import { useRoute } from "#imports";
 import TorrentActionCard from "~/components/torrent/TorrentActionCard.vue";
 import TorrentDescriptionTab from "~/components/torrent/TorrentDescriptionTab.vue";
 import TorrentFilesTab from "~/components/torrent/TorrentFilesTab.vue";

--- a/composables/states.ts
+++ b/composables/states.ts
@@ -1,7 +1,7 @@
 import { PublicSettings, Category, TokenResponse, TorrentTag } from "torrust-index-types-lib";
 import { Rest } from "torrust-index-api-lib";
 import { notify } from "notiwind-ts";
-import { useRuntimeConfig, useState } from "#app";
+import { useRuntimeConfig, useState } from "#imports";
 
 export const useRestApi = () => useState<Rest>("rest-api", () => new Rest(useRuntimeConfig().public.apiBase));
 export const useCategories = () => useState<Array<Category>>("categories", () => new Array<Category>());

--- a/plugins/notifications.client.ts
+++ b/plugins/notifications.client.ts
@@ -1,5 +1,5 @@
 import Notifications from "notiwind-ts";
-import { defineNuxtPlugin } from "#app";
+import { defineNuxtPlugin } from "#imports";
 
 export default defineNuxtPlugin((nuxtApp) => {
   nuxtApp.vueApp.use(Notifications);


### PR DESCRIPTION
This is a DX improvement when developing - we can avoid loading the entire barrel file at `#app` by using the new granular imports merged in https://github.com/nuxt/nuxt/pull/23951.