### PR TITLE
Use NITRO env vars for `NITRO_HOST` and `NITRO_HOST`

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -35,15 +35,17 @@ RUN ["/busybox/cp", "-sp", "/busybox/sh","/busybox/cat","/busybox/ls","/busybox/
 COPY --from=gcc --chmod=0555 /usr/local/bin/su-exec /bin/su-exec
 
 ARG USER_ID=1000
-ARG INDEX_GUI_PORT=3000
 ARG NUXT_PUBLIC_API_BASE0=http://localhost:3001/v1
+ARG NITRO_HOST=::
+ARG NITRO_PORT=3000
 
 ENV TZ=Etc/UTC
 ENV USER_ID=${USER_ID}
-ENV INDEX_GUI_PORT=${INDEX_GUI_PORT}
 ENV NUXT_PUBLIC_API_BASE=${NUXT_PUBLIC_API_BASE}
+ENV NITRO_HOST=${NITRO_HOST}
+ENV NITRO_PORT=${NITRO_PORT}
 
-EXPOSE $INDEX_GUI_PORT/tcp
+EXPOSE $NITRO_PORT/tcp
 
 RUN mkdir -p /var/log/torrust/tracker
 
@@ -69,5 +71,5 @@ FROM runtime as release
 ENV RUNTIME="release"
 COPY --from=test /app/.output /app/.output
 HEALTHCHECK --interval=5s --timeout=5s --start-period=3s --retries=3 \
-  CMD /nodejs/bin/node /usr/local/bin/health_check.js ${INDEX_GUI_PORT} || exit 1
+  CMD /nodejs/bin/node /usr/local/bin/health_check.js ${NITRO_PORT} || exit 1
 CMD [ "/nodejs/bin/node", "/app/.output/server/index.mjs" ]

--- a/compose.yaml
+++ b/compose.yaml
@@ -12,6 +12,8 @@ services:
     environment:
       - USER_ID=${USER_ID}
       - NUXT_PUBLIC_API_BASE=${TORRUST_INDEX_GUI_API_BASE_URL:-http://localhost:3001/v1}
+      - NITRO_HOST=${NITRO_HOST:-::}
+      - NITRO_PORT=${NITRO_PORT:-3000}
     ports:
       - 3000:3000
       - 24678:24678

--- a/contrib/dev-tools/container/docker-run-local.sh
+++ b/contrib/dev-tools/container/docker-run-local.sh
@@ -5,5 +5,7 @@ mkdir -p ./storage/index-gui/lib/ ./storage/index-gui/log/ ./storage/index-gui/e
 docker run -it \
     --env USER_ID="$(id -u)" \
     --env NUXT_PUBLIC_API_BASE="http://localhost:3001/v1" \
-    --publish 3000:3000/tcp \
+    --env NITRO_HOST="::" \
+    --env NITRO_PORT="3000" \
+    --publish "3000:3000/tcp" \
     torrust-index-gui:release

--- a/contrib/dev-tools/container/docker-run-public.sh
+++ b/contrib/dev-tools/container/docker-run-public.sh
@@ -5,5 +5,7 @@ mkdir -p ./storage/index-gui/log/
 docker run -it \
     --env USER_ID="$(id -u)" \
     --env NUXT_PUBLIC_API_BASE="http://localhost:3001/v1" \
-    --publish 3000:3000/tcp \
+    --env NITRO_HOST="::" \
+    --env NITRO_PORT="3000" \
+    --publish "3000:3000/tcp" \
     torrust/index-gui:latest

--- a/docs/containers.md
+++ b/docs/containers.md
@@ -168,8 +168,9 @@ Environmental variables are loaded through the `--env`, in the format `--env VAR
 The following environmental variables can be set:
 
 - `USER_ID` - The user id for the runtime crated `torrust` user. Please Note: This user id should match the ownership of the host-mapped volumes, (default `1000`).
-- `INDEX_GUI_PORT` - The port on which the web application is served (default `3000`).
 - `NUXT_PUBLIC_API_BASE` - The base [Index API](https://github.com/torrust/torrust-index) URL the frontend connects to (default `http://localhost:3001/v1`).
+- `NITRO_HOST` - The IP on which the web application socket is bound to (default loopback IPv6 `::`).
+- `NITRO_PORT` - The por on which the web application is served (default `3000`).
 
 ### Sockets
 
@@ -217,22 +218,20 @@ mkdir -p ./storage/index-gui/log/
 ## Run Torrust Index GUI Container Image (IPv6)
 docker run -it \
     --env USER_ID="$(id -u)" \
-    --env INDEX_GUI_PORT="3000" \
     --env NUXT_PUBLIC_API_BASE="http://localhost:3001/v1" \
     --env NITRO_HOST="::" \
     --env NITRO_PORT="3000" \
-    --publish [::]:3000:3000/tcp \
+    --publish "3000:3000/tcp" \
     --volume ./storage/index-gui/log:/var/log/torrust/index-gui:Z \
     torrust-index-gui:release
 
 ## Run Torrust Index GUI Container Image (IPv4)
 docker run -it \
     --env USER_ID="$(id -u)" \
-    --env INDEX_GUI_PORT="3000" \
     --env NUXT_PUBLIC_API_BASE="http://localhost:3001/v1" \
     --env NITRO_HOST="0.0.0.0" \
     --env NITRO_PORT="3000" \
-    --publish 0.0.0.0:3000:3000/tcp \
+    --publish "3000:3000/tcp" \
     --volume ./storage/index-gui/log:/var/log/torrust/index-gui:Z \
     torrust-index-gui:release
 ```
@@ -249,22 +248,20 @@ mkdir -p ./storage/index-gui/log/
 ## Run Torrust Index GUI Container Image (IPv6)
 podman run -it \
     --env USER_ID="$(id -u)" \
-    --env INDEX_GUI_PORT="3000" \
     --env NUXT_PUBLIC_API_BASE="http://localhost:3001/v1" \
     --env NITRO_HOST="::" \
     --env NITRO_PORT="3000" \
-    --publish [::]:3000:3000/tcp \
+    --publish "3000:3000/tcp" \
     --volume ./storage/index-gui/log:/var/log/torrust/index-gui:Z \
     torrust-index-gui:release
 
 ## Run Torrust Index GUI Container Image (IPv4)
 podman run -it \
     --env USER_ID="$(id -u)" \
-    --env INDEX_GUI_PORT="3000" \
     --env NUXT_PUBLIC_API_BASE="http://localhost:3001/v1" \
     --env NITRO_HOST="0.0.0.0" \
     --env NITRO_PORT="3000" \
-    --publish 0.0.0.0:3000:3000/tcp \
+    --publish "3000:3000/tcp" \
     --volume ./storage/index-gui/log:/var/log/torrust/index-gui:Z \
     torrust-index-gui:release
 ```


### PR DESCRIPTION
Use NITRO env vars for `NITRO_HOST` and `NITRO_HOST` and remove env var `INDEX_GUI_PORT`. Now you can use `NITRO_PORT`.

We were using `INDEX_GUI_PORT` to expose the container port but we were not changing the default NITRO port.

See: https://nitro.unjs.io/deploy/runtimes/node#environment-variables

Since we have to use `NITRO_HOST` we do not need anymore the `INDEX_GUI_PORT` var.