### PR TITLE
Fix missing tracker key in announce URLs when a logged in user download a torrent

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "dompurify": "^3.0.5",
         "marked": "^9.1.5",
         "notiwind-ts": "^2.0.2",
-        "torrust-index-api-lib": "^1.0.0-alpha.4",
+        "torrust-index-api-lib": "^1.0.0-alpha.5",
         "torrust-index-types-lib": "^1.0.0-alpha.4",
         "uuid": "^9.0.0"
       },
@@ -18148,9 +18148,9 @@
       }
     },
     "node_modules/torrust-index-api-lib": {
-      "version": "1.0.0-alpha.4",
-      "resolved": "https://registry.npmjs.org/torrust-index-api-lib/-/torrust-index-api-lib-1.0.0-alpha.4.tgz",
-      "integrity": "sha512-RsPGdv1fl0j975Mbf3auJZWYjahxJPca6M7L3IqPlG+bCjc0yQmobr4QAETbYc2U1HHnKyGJaPEiOi5VxTCywg==",
+      "version": "1.0.0-alpha.5",
+      "resolved": "https://registry.npmjs.org/torrust-index-api-lib/-/torrust-index-api-lib-1.0.0-alpha.5.tgz",
+      "integrity": "sha512-kLa6Yc7s1/+lRH30OiGI2SxQpKiBt8EAKQma3QVzdj1cNSa5T3kURhfhKsCkgwQQCq1/SbZl7PMNesQOgqPROQ==",
       "dependencies": {
         "torrust-index-types-lib": "^1.0.0-alpha.4"
       }

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "dompurify": "^3.0.5",
     "marked": "^9.1.5",
     "notiwind-ts": "^2.0.2",
-    "torrust-index-api-lib": "^1.0.0-alpha.4",
+    "torrust-index-api-lib": "^1.0.0-alpha.5",
     "torrust-index-types-lib": "^1.0.0-alpha.4",
     "uuid": "^9.0.0"
   }


### PR DESCRIPTION
Becuase the Auth Bearer Token was not being added to all API requests, including the GET request to download the torrent file.