### PR TITLE
Add torrent title in `TorrentDetails` component

### DIFF
--- a/components/torrent/TorrentDetails.vue
+++ b/components/torrent/TorrentDetails.vue
@@ -15,6 +15,7 @@
                 </button>
               </div>
               <div v-if="torrent" class="flex flex-col flex-auto w-full gap-6">
+                <span class="text-lg font-bold capitalize truncate" :v-if="torrent">{{ torrent.title }}</span>
                 <TorrentDescriptionTab :torrent="torrent" @updated="reloadTorrent" />
                 <TorrentCommentTab :torrent="torrent" @updated="reloadTorrent" />
                 <TorrentCreationDateTab :torrent="torrent" @updated="reloadTorrent" />


### PR DESCRIPTION
It's duplicated in the ActionCard component. But with small screens the action card is on top of the detail tabs.