### PR TITLE
Fix `WARN  Using postcss.config.js is not supported together w…`

### DIFF
--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -41,6 +41,13 @@ export default defineNuxtConfig({
 
   devtools: {
     enabled: true
-  }
+  },
 
+  postcss: {
+    plugins: {
+      "tailwindcss/nesting": {},
+      tailwindcss: {},
+      autoprefixer: {}
+    }
+  }
 });

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,7 +1,0 @@
-module.exports = {
-  plugins: {
-    "tailwindcss/nesting": {},
-    tailwindcss: {},
-    autoprefixer: {}
-  }
-};


### PR DESCRIPTION
It fixes this build warning:

```
WARN  Using postcss.config.js is not supported together with Nuxt. Use options.postcss instead. You can read more in https://nuxt.com/docs/api/configuration/nuxt-config#postcss.
```