### PR TITLE
Rename button "download torrent" to "download private torrent" when the tracker is in close mode

### DIFF
--- a/components/torrent/TorrentActionCard.vue
+++ b/components/torrent/TorrentActionCard.vue
@@ -110,18 +110,7 @@
             </button>
           </template>
           <template v-else>
-            <button
-              class="h-12 px-4 mt-3 text-sm font-medium text-black bg-white rounded-2xl"
-              @click="$store.dispatch('openAuthModal')"
-            >
-              Please sign in to download
-            </button>
-            <button
-              class="h-12 px-4 mt-3 text-sm font-medium text-white bg-sky-500 rounded-2xl"
-              @click="$store.dispatch('openAuthModal')"
-            >
-              Please sign in to download
-            </button>
+              <NuxtLink to="/signin">Private tracker. Sign in to download torrent or magnet link.</NuxtLink>
           </template>
         </div>
 
@@ -208,5 +197,9 @@ function deleteTorrent () {
         text: `Trying to delete the torrent. ${err.message}.`
       }, 10000);
     });
+}
+
+function navigateToSignIn () {
+  navigateTo("/signin", { replace: true });
 }
 </script>

--- a/components/torrent/TorrentActionCard.vue
+++ b/components/torrent/TorrentActionCard.vue
@@ -156,7 +156,7 @@ import {
   downloadTorrent,
   useRestApi,
   isUserLoggedIn,
-  isTrackerPublic, navigateTo
+  isTrackerOpen, navigateTo
 } from "#imports";
 import { canEditThisTorrent } from "~/composables/helpers";
 
@@ -179,7 +179,7 @@ function hasEditRights (): boolean {
 }
 
 function showDownloadButtons (): boolean {
-  return isUserLoggedIn() || isTrackerPublic();
+  return isUserLoggedIn() || isTrackerOpen();
 }
 
 function seedersPercentage () {

--- a/components/torrent/TorrentActionCard.vue
+++ b/components/torrent/TorrentActionCard.vue
@@ -101,7 +101,7 @@
         <div class="flex flex-row gap-3">
           <template v-if="showDownloadButtons()">
             <button class="btn btn-primary grow" data-cy="torrent-action-download" @click="downloadTorrent(torrent.info_hash, torrent.name)">
-              download torrent
+              download {{ isTrackerClose()? 'private' : '' }} torrent
             </button>
             <button class="w-12 p-0 btn btn-primary">
               <a data-cy="torrent-action-magnet-link" class="flex items-center" :href="torrent.magnet_link">
@@ -145,7 +145,7 @@ import {
   downloadTorrent,
   useRestApi,
   isUserLoggedIn,
-  isTrackerOpen, navigateTo
+  isTrackerOpen, isTrackerClose, navigateTo
 } from "#imports";
 import { canEditThisTorrent } from "~/composables/helpers";
 

--- a/components/torrent/TorrentActionCard.vue
+++ b/components/torrent/TorrentActionCard.vue
@@ -99,7 +99,7 @@
         <div />
 
         <div class="flex flex-row gap-3">
-          <template v-if="showDownloadButtons">
+          <template v-if="showDownloadButtons()">
             <button class="btn btn-primary grow" data-cy="torrent-action-download" @click="downloadTorrent(torrent.info_hash, torrent.name)">
               download torrent
             </button>
@@ -178,7 +178,7 @@ function hasEditRights (): boolean {
   return canEditThisTorrent(props.torrent);
 }
 
-function showDownloadButtons () {
+function showDownloadButtons (): boolean {
   return isUserLoggedIn() || isTrackerPublic();
 }
 

--- a/composables/helpers.ts
+++ b/composables/helpers.ts
@@ -4,8 +4,15 @@ import { useRestApi, useSettings, useUser } from "~/composables/states";
 export function isTrackerOpen (): boolean {
   const settings = useSettings();
 
-  return settings.value.tracker_mode === TrackerMode.Public ||
-        settings.value.tracker_mode === TrackerMode.Whitelisted;
+  // todo: we are not using the type TrackerMode in
+  // settings.value.tracker_mode
+
+  return settings.value.tracker_mode === "Public" ||
+        settings.value.tracker_mode === "Whitelisted";
+}
+
+export function isTrackerClose (): boolean {
+  return !isTrackerOpen();
 }
 
 export function isUserLoggedIn (): boolean {

--- a/composables/helpers.ts
+++ b/composables/helpers.ts
@@ -1,7 +1,7 @@
 import { TorrentResponse, TrackerMode } from "torrust-index-types-lib";
 import { useRestApi, useSettings, useUser } from "~/composables/states";
 
-export function isTrackerPublic (): boolean {
+export function isTrackerOpen (): boolean {
   const settings = useSettings();
 
   return settings.value.tracker_mode === TrackerMode.Public ||

--- a/cypress/e2e/contexts/user/tasks.ts
+++ b/cypress/e2e/contexts/user/tasks.ts
@@ -9,6 +9,10 @@ export const grantAdminRole = async (username: string, db_config: DatabaseConfig
   try {
     const result = await runDatabaseQuery(getUserIdByUsernameQuery(username), db_config);
 
+    if (result === undefined || result.user_id === undefined) {
+      throw new Error(`Can't grant admin role to user. No user found with username: ${username} in database: ${db_config.filepath}`);
+    }
+
     const user_id = result.user_id;
 
     await runDatabaseQuery(grantAdminRoleQuery(user_id), db_config);
@@ -25,6 +29,10 @@ export const deleteUser = async (username: string, db_config: DatabaseConfig): P
 
   try {
     const result = await runDatabaseQuery(getUserIdByUsernameQuery(username), db_config);
+
+    if (result === undefined || result.user_id === undefined) {
+      throw new Error(`Can't delete user. No user found with username: ${username} in database: ${db_config.filepath}`);
+    }
 
     const user_id = result.user_id;
 


### PR DESCRIPTION
- [x] Fix bug. The button was always shown even when the tracker was private and the user was not logged in.
- [x] Fix bug. The function to detect tracker mode was not working.
- [x] Rename the button for private trackers.
- [x] Improve error message when tasks in the database for users fail.