### PR TITLE
After uploading a torrent show a message to the user if the torrent info-hash changes

### DIFF
--- a/docs/user_guide.md
+++ b/docs/user_guide.md
@@ -24,6 +24,33 @@ You can add a PNG image with:
 
 The image will be proxied by the backend. This means that the image will be downloaded by the backend and served by the backend itself. The backend will cache the image but you have to make sure that the image is available at the URL you provided.
 
+### Canonical Infohash Group
+
+We only support standard fields in the torrent info dictionary.
+
+```rust
+pub struct TorrentInfoDictionary {
+    pub name: String,
+    pub pieces: Option<ByteBuf>,
+    pub piece_length: i64,
+    pub md5sum: Option<String>,
+    pub length: Option<i64>,
+    pub files: Option<Vec<TorrentFile>>,
+    pub private: Option<u8>,
+    pub path: Option<Vec<String>>,
+    pub root_hash: Option<String>,
+    pub source: Option<String>,
+}
+```
+
+Check the data structure [TorrentInfoDictionary](https://github.com/torrust/torrust-index/blob/develop/src/models/torrent_file.rs) for an updated version of the supported fields.
+
+We allow uploading torrents with other custom fields, however those extra fields are removed from the torrent `info` dictionary. That causes the infohash to change. We call the "Canonical Infohash" the resulting infohash after removing the non-standard fields from the `info` dictionary.
+
+You can use the original infohash in URLs to navigate to the torrent details and you also have a list of original infohashes belonging to the same infohash group in the torrent details.
+
+If you think there is an important field missing in the `info` dictionary, please open an issue.
+
 ## Categories
 
 Torrents can have only one category. You have to assign a category to your torrent when you upload it.

--- a/pages/upload.vue
+++ b/pages/upload.vue
@@ -160,11 +160,17 @@ function submitForm () {
     .then((new_torrent) => {
       uploading.value = false;
 
+      let text = "Torrent uploaded!";
+
+      if (new_torrent.canonical_info_hash !== new_torrent.info_hash) {
+        text += ` Original infohash ${new_torrent.info_hash} has changed because non-standard info dictionary fields were removed. New infohash is ${new_torrent.canonical_info_hash}`;
+      }
+
       notify({
         group: "success",
         title: "Success",
-        text: "Torrent uploaded!"
-      }, 4000);
+        text
+      }, 8000);
 
       navigateTo(`/torrent/${new_torrent.canonical_info_hash}`, { replace: true });
     })

--- a/project-words.txt
+++ b/project-words.txt
@@ -16,5 +16,6 @@ nuxtjs
 proxied
 Quickstart
 signin
+struct
 uuidv
 vuex


### PR DESCRIPTION
After uploading a torrent show a message to the user if the torrent info-hash changes.