### PR TITLE
Add new link to user guide closes #547

### DIFF
--- a/components/navigation/NavigationBar.vue
+++ b/components/navigation/NavigationBar.vue
@@ -34,6 +34,7 @@
               <li v-if="user.admin" data-cy="admin-settings-link"><NuxtLink to="/admin/settings/backend">
                 Admin Settings
               </NuxtLink></li>
+              <li><a data-cy="help" href="https://torrust.github.io/torrust-index-gui-user-guide/" target="_blank">Help</a></li>
               <li><a data-cy="logout-link" @click="logoutUser()">Logout {{ user.username }}</a></li>
             </ul>
           </div>

--- a/cypress/e2e/contexts/torrent/specs/list/magnet_link.cy.ts
+++ b/cypress/e2e/contexts/torrent/specs/list/magnet_link.cy.ts
@@ -27,8 +27,8 @@ describe("A guest user", () => {
 
   it("should be able get the a torrent magnet link from the torrents list", () => {
     // Get the magnet link
-    cy.get("[data-cy=\"torrent-list-magnet-link\"]").invoke("attr", "").then(() => {
-      expect().to.include(`magnet:?xt=urn:btih:${Cypress.env("infoHash")}`);
+    cy.get("[data-cy=\"torrent-list-magnet-link\"]").invoke("attr", "href").then((href) => {
+      expect(href).to.include(`magnet:?xt=urn:btih:${Cypress.env("infoHash")}`);
     });
   });
 
@@ -36,8 +36,8 @@ describe("A guest user", () => {
     // Sets the layout to "table"
     cy.get("[data-cy=\"torrents-table-layout-selector\"]").click();
     // Gets the magnet link
-    cy.get("[data-cy=\"torrent-table-magnet-link\"]").invoke("attr", "").then(() => {
-      expect().to.include(`magnet:?xt=urn:btih:${Cypress.env("infoHash")}`);
+    cy.get("[data-cy=\"torrent-table-magnet-link\"]").invoke("attr", "href").then((href) => {
+      expect(href).to.include(`magnet:?xt=urn:btih:${Cypress.env("infoHash")}`);
     });
   });
 });

--- a/cypress/e2e/contexts/torrent/specs/list/magnet_link.cy.ts
+++ b/cypress/e2e/contexts/torrent/specs/list/magnet_link.cy.ts
@@ -27,8 +27,8 @@ describe("A guest user", () => {
 
   it("should be able get the a torrent magnet link from the torrents list", () => {
     // Get the magnet link
-    cy.get("[data-cy=\"torrent-list-magnet-link\"]").invoke("attr", "href").then((href) => {
-      expect(href).to.include(`magnet:?xt=urn:btih:${Cypress.env("infoHash")}`);
+    cy.get("[data-cy=\"torrent-list-magnet-link\"]").invoke("attr", "").then(() => {
+      expect().to.include(`magnet:?xt=urn:btih:${Cypress.env("infoHash")}`);
     });
   });
 
@@ -36,8 +36,8 @@ describe("A guest user", () => {
     // Sets the layout to "table"
     cy.get("[data-cy=\"torrents-table-layout-selector\"]").click();
     // Gets the magnet link
-    cy.get("[data-cy=\"torrent-table-magnet-link\"]").invoke("attr", "href").then((href) => {
-      expect(href).to.include(`magnet:?xt=urn:btih:${Cypress.env("infoHash")}`);
+    cy.get("[data-cy=\"torrent-table-magnet-link\"]").invoke("attr", "").then(() => {
+      expect().to.include(`magnet:?xt=urn:btih:${Cypress.env("infoHash")}`);
     });
   });
 });


### PR DESCRIPTION
The "Help" option has been added as a link above the logout option in the user options located at the top right corner.