### PR TITLE
Fix: revert link removed in torrent list to torrent details

### DIFF
--- a/components/torrent/TorrentList.vue
+++ b/components/torrent/TorrentList.vue
@@ -41,7 +41,11 @@
         </div>
         <template v-if="isOpenList[index]">
           <div class="flex flex-row items-start justify-start w-full px-4 pt-2 pb-4 duration-1000 flex-nowrap">
-            <TorrentListTorrentDetails :description="torrent.description" />
+            <TorrentListTorrentDetails
+              :info-hash="torrent.info_hash"
+              :title="torrent.title"
+              :description="torrent.description"
+            />
           </div>
         </template>
       </a>

--- a/components/torrent/TorrentListTorrentDetails.vue
+++ b/components/torrent/TorrentListTorrentDetails.vue
@@ -1,6 +1,7 @@
 <template>
   <div
     class="flex flex-col items-center w-full group/details rounded-2xl"
+    @click.stop="$router.push(`/torrent/${props.infoHash}/${slug}`)"
   >
     <div class="flex justify-center w-full p-4 overflow-y-auto duration-500 border-2 max-h-96 border-base-content/20 hover:border-primary text-base-content/75 rounded-2xl">
       <template v-if="description !== null">
@@ -14,13 +15,24 @@
 </template>
 
 <script setup lang="ts">
+import { generateSlug } from "~/src/domain/services/slug";
 
 const props = defineProps({
+  infoHash: {
+    type: String,
+    required: true
+  },
+  title: {
+    type: String,
+    required: true
+  },
   description: {
     type: String,
     required: true
   }
 });
+
+const slug = computed(() => generateSlug(props.title));
 
 </script>
 


### PR DESCRIPTION
Revert link removed in the torrent list to torrent details. It was removed on commit fac420435eab5d187aac08f244a764cc365b8e8d.