### PR TITLE
Update tracker configuration

### DIFF
--- a/share/default/config/tracker.private.e2e.container.sqlite3.toml
+++ b/share/default/config/tracker.private.e2e.container.sqlite3.toml
@@ -1,5 +1,7 @@
+version = "2"
+
 [core]
-mode = "private"
+private = true
 
 [core.database]
 path = "/var/lib/torrust/tracker/database/e2e_testing_sqlite3.db"

--- a/share/default/config/tracker.public.e2e.container.sqlite3.toml
+++ b/share/default/config/tracker.public.e2e.container.sqlite3.toml
@@ -1,6 +1,7 @@
+version = "2"
+
 [core.database]
 path = "/var/lib/torrust/tracker/database/e2e_testing_sqlite3.db"
 
 [http_api]
 bind_address = "0.0.0.0:1212"
-


### PR DESCRIPTION
New breaking changes have been applied to the Tracker configuration.

- Renamed `log_level` to  `threshold`.
- Tracker mode split into `listed` and `private` flags.
- Added configuration `version`.

From:

```toml
[logging]
log_level = "info"

[core]
mode = "public"
tracker_usage_statistics = true
inactive_peer_cleanup_interval = 600
```

To:

```toml
version = "2"

[logging]
threshold = "info"

[core]
inactive_peer_cleanup_interval = 600
listed = false
private = false
tracker_usage_statistics = true
```