### PR TITLE
Allow an empty email field in the registration form when email is optional

### DIFF
--- a/components/registration/RegistrationForm.vue
+++ b/components/registration/RegistrationForm.vue
@@ -12,7 +12,7 @@
         <template v-if="settings && settings.email_on_signup !== EmailOnSignup.Ignored">
           <FormInputText
             v-model="form.email"
-            type="email"
+            :type="settings.email_on_signup === EmailOnSignup.Required || form.email !== '' ? 'email' : 'text'"
             label="Email"
             name="email"
             data-cy="registration-form-email"


### PR DESCRIPTION
Depends on: https://github.com/torrust/torrust-index/pull/670

Allow an empty email field in the registration form when email is optional in the configuration.

To be fully fixed this [PR](https://github.com/torrust/torrust-index/pull/670) has to be merged.

