### PR TITLE
Udate Index TOML config file

### DIFF
--- a/share/default/config/index.private.e2e.container.sqlite3.toml
+++ b/share/default/config/index.private.e2e.container.sqlite3.toml
@@ -11,3 +11,9 @@ connect_url = "sqlite:///var/lib/torrust/index/database/e2e_testing_sqlite3.db?m
 [mail.smtp]
 port = 1025
 server = "mailcatcher"
+
+[registration]
+
+[registration.email]
+#required = false
+#verified = false

--- a/share/default/config/index.public.e2e.container.sqlite3.toml
+++ b/share/default/config/index.public.e2e.container.sqlite3.toml
@@ -11,3 +11,9 @@ connect_url = "sqlite:///var/lib/torrust/index/database/e2e_testing_sqlite3.db?m
 [mail]
 port = 1025
 server = "mailcatcher"
+
+[registration]
+
+[registration.email]
+#required = false
+#verified = false


### PR DESCRIPTION
Relates to: https://github.com/torrust/torrust-index/pull/670

These two config option in the Index TOML config file have been removed:

```toml
[auth]
email_on_signup = "optional"

[mail]
email_verification_enabled = false
```

We need to replace them with:

```toml
[registration]
[registration.email]
```