### PR TITLE
New static page with terms

### DIFF
--- a/app.vue
+++ b/app.vue
@@ -12,7 +12,7 @@
     <div class="flex-grow" />
     <footer class="p-4 footer footer-center text-base-content">
       <div>
-        <p><a target="_blank" href="https://torrust.com" class="link link-hover"> Powered by Torrust </a> ⚡ <a target="_self" href="/license" class="link link-hover">Copyright © 2024</a></p>
+        <p><a target="_blank" href="https://torrust.com" class="link link-hover"> Powered by Torrust </a> ⚡ <a target="_self" href="/license" class="link link-hover">Copyright © 2024</a> &nbsp; <a target="_self" href="/terms" class="link link-hover">Terms</a></p>
       </div>
     </footer>
   </div>

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,8 +17,8 @@
         "dompurify": "^3.1.4",
         "marked": "^12.0.2",
         "notiwind-ts": "^2.0.2",
-        "torrust-index-api-lib": "^3.0.0-beta",
-        "torrust-index-types-lib": "^3.0.0-beta",
+        "torrust-index-api-lib": "^3.0.0-beta.2",
+        "torrust-index-types-lib": "^3.0.0-beta.2",
         "uuid": "^9.0.1"
       },
       "devDependencies": {
@@ -42,6 +42,13 @@
         "sqlite3": "^5.1.7",
         "typescript": "^5.4.5",
         "vite-plugin-eslint": "^1.8.1"
+      }
+    },
+    "../torrust-index-types-lib": {
+      "version": "3.0.0-beta.2",
+      "license": "SEE LICENSE IN COPYRIGHT",
+      "devDependencies": {
+        "typescript": "^5.2.2"
       }
     },
     "node_modules/@alloc/quick-lru": {
@@ -20324,19 +20331,17 @@
       }
     },
     "node_modules/torrust-index-api-lib": {
-      "version": "3.0.0-beta",
-      "resolved": "https://registry.npmjs.org/torrust-index-api-lib/-/torrust-index-api-lib-3.0.0-beta.tgz",
-      "integrity": "sha512-CbNOjneTiuChZ/xDfLosVIbZ6zdS06GBbeezsJ+2AofJXbAu7Q8KFgWnLJUZUVMtqiELc83CZflC7EVGubif3A==",
+      "version": "3.0.0-beta.2",
+      "resolved": "https://registry.npmjs.org/torrust-index-api-lib/-/torrust-index-api-lib-3.0.0-beta.2.tgz",
+      "integrity": "sha512-hfgK5LmEnHLcW4imTvBMtrFM8w/4ccqsMfaYFIMpQargjhHTmE1xgjoFPc4apa9SKYTyvLs3i+StDXPO3ar3rA==",
       "license": "SEE LICENSE IN COPYRIGHT",
       "dependencies": {
-        "torrust-index-types-lib": "^3.0.0-beta"
+        "torrust-index-types-lib": "^3.0.0-beta.2"
       }
     },
     "node_modules/torrust-index-types-lib": {
-      "version": "3.0.0-beta",
-      "resolved": "https://registry.npmjs.org/torrust-index-types-lib/-/torrust-index-types-lib-3.0.0-beta.tgz",
-      "integrity": "sha512-OoNnvhvRy9D+DnsgTWvRTRwbys6kusPfRggfzuM40G+8iH/9gvJvvELKZrVflw3rb1zOpNsuJ8UVN7e2Y23tFA==",
-      "license": "SEE LICENSE IN COPYRIGHT"
+      "resolved": "../torrust-index-types-lib",
+      "link": true
     },
     "node_modules/totalist": {
       "version": "3.0.1",

--- a/package.json
+++ b/package.json
@@ -48,8 +48,8 @@
     "dompurify": "^3.1.4",
     "marked": "^12.0.2",
     "notiwind-ts": "^2.0.2",
-    "torrust-index-api-lib": "^3.0.0-beta",
-    "torrust-index-types-lib": "^3.0.0-beta",
+    "torrust-index-api-lib": "^3.0.0-beta.2",
+    "torrust-index-types-lib": "^3.0.0-beta.2",
     "uuid": "^9.0.1"
   }
 }

--- a/pages/terms.vue
+++ b/pages/terms.vue
@@ -1,0 +1,34 @@
+<template>
+  <div>
+    <Markdown :source="pageContent" class="px-40 pt-2 pb-5 prose-h1:text-center max-w-none" />
+  </div>
+</template>
+
+<script setup lang="ts">
+import { ref, watch } from "vue";
+import { useSettings, useSeoMeta } from "#imports";
+
+const settings = useSettings();
+
+const pageTitle = ref("");
+const pageContent = ref("");
+
+watch(
+  () => settings.value,
+  (newSettings) => {
+    if (newSettings?.website?.terms?.page) {
+      pageTitle.value = newSettings.website.terms.page.title;
+      pageContent.value = newSettings.website.terms.page.content;
+    }
+  },
+  { immediate: true }
+);
+
+useSeoMeta({
+  title: () => `${pageTitle.value} - Torrent`
+});
+</script>
+
+<style scoped>
+
+</style>


### PR DESCRIPTION
Depends on:

- https://github.com/torrust/torrust-index-types-lib/pull/25
- https://github.com/torrust/torrust-index/pull/731

URL: http://localhost:3000/terms

It also adds a link in the footer. The page content is loaded in markdown format from the API (settings->website).