### PR TITLE
Add demo warning banner

### DIFF
--- a/app.vue
+++ b/app.vue
@@ -1,5 +1,7 @@
 <template>
   <div class="flex flex-col" style="min-height: 100vh;">
+    <DemoBanner />
+
     <Notifications />
 
     <NavigationBar />
@@ -21,6 +23,7 @@
 <script setup lang="ts">
 import { getCategories, getSettings, getTags, getUser, onBeforeMount, onMounted } from "#imports";
 import Notifications from "~/components/Notifications.vue";
+import DemoBanner from "~/components/demo/Banner.vue";
 
 onBeforeMount(() => {
   getUser();

--- a/components/demo/Banner.vue
+++ b/components/demo/Banner.vue
@@ -1,0 +1,44 @@
+<template>
+  <div v-if="isDemoMode" class="demo-banner">
+    {{ warning }}<NuxtLink to="/terms">
+      Read our terms.</NuxtLink>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { type PublicSettings } from "torrust-index-types-lib";
+
+const settings = useSettings();
+const isDemoMode = ref(false);
+const warning = ref("");
+
+onMounted(() => {
+  isDemoMode.value = false;
+});
+
+watch(
+  () => settings.value,
+  (newSettings) => {
+    if (newSettings?.website?.demo?.warning) {
+      isDemoMode.value = true;
+      warning.value = newSettings?.website?.demo?.warning;
+    }
+  },
+  { immediate: true }
+);
+
+</script>
+
+<style scoped>
+.demo-banner {
+  background-color: #f5b14a;
+  color: #000;
+  width: 100%;
+  padding: 10px;
+  text-align: center;
+  /*position: fixed;*/
+  top: 0;
+  left: 0;
+  z-index: 1000;
+}
+</style>

--- a/package-lock.json
+++ b/package-lock.json
@@ -44,13 +44,6 @@
         "vite-plugin-eslint": "^1.8.1"
       }
     },
-    "../torrust-index-types-lib": {
-      "version": "3.0.0-beta.2",
-      "license": "SEE LICENSE IN COPYRIGHT",
-      "devDependencies": {
-        "typescript": "^5.2.2"
-      }
-    },
     "node_modules/@alloc/quick-lru": {
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/@alloc/quick-lru/-/quick-lru-5.2.0.tgz",
@@ -20340,8 +20333,10 @@
       }
     },
     "node_modules/torrust-index-types-lib": {
-      "resolved": "../torrust-index-types-lib",
-      "link": true
+      "version": "3.0.0-beta.2",
+      "resolved": "https://registry.npmjs.org/torrust-index-types-lib/-/torrust-index-types-lib-3.0.0-beta.2.tgz",
+      "integrity": "sha512-xyKROjcPMrdhO3ay8t5+P+WB/strjx61s+MMWcYvqPacBEP1fUVyxp/ihbVS+cvMHmA1Q1MzVWaypcxKYsnNHQ==",
+      "license": "SEE LICENSE IN COPYRIGHT"
     },
     "node_modules/totalist": {
       "version": "3.0.1",


### PR DESCRIPTION
Add demo warning banner. The text can be overridden in the Index configuration:

```
[website.demo]
warning = """
⚠️ Please be aware: This demo resets all data weekly. Torrents not complying with our Usage Policies will be removed immediately without notice. We encourage the responsible use of this software in compliance with all legal requirements.
"""
```

See https://github.com/torrust/torrust-index/issues/730
