### PR TITLE
Fix searched users not displaying properly when actual page is larger than 1

### DIFF
--- a/pages/admin/settings/users.vue
+++ b/pages/admin/settings/users.vue
@@ -42,7 +42,7 @@ watch(() => route.fullPath, () => {
   pageSize.value = isNaN(route.query.pageSize) ? defaultPageSize : parseInt(route.query.pageSize);
 });
 
-watch([searchQuery, currentPage], () => {
+watch(currentPage, () => {
   router.push({
     query: {
       search: searchQuery.value,
@@ -55,7 +55,7 @@ watch([searchQuery, currentPage], () => {
 });
 
 // Resets the current page value to 1 when the page size is changed to display results correctly
-watch(pageSize, () => {
+watch([pageSize, searchQuery], () => {
   router.push({
     query: {
       search: searchQuery.value,


### PR DESCRIPTION
Current page has to be reset to 1 when searching users, this PR fix actual page not resetting when searching for users.